### PR TITLE
bugfix

### DIFF
--- a/microsphere-nacos-openapi/src/main/java/io/microsphere/nacos/client/constants/Constants.java
+++ b/microsphere-nacos-openapi/src/main/java/io/microsphere/nacos/client/constants/Constants.java
@@ -120,7 +120,7 @@ public interface Constants {
     /**
      * The default value of the long polling timeout for Nacos Client : 30 seconds
      */
-    int DEFAULT_LONG_POLLING_TIMEOUT = (int) SECONDS.toMicros(30);
+    int DEFAULT_LONG_POLLING_TIMEOUT = (int) SECONDS.toMillis(30);
 
     /**
      * The default value of the event processing timeout for Nacos Client : 30 seconds

--- a/microsphere-nacos-openapi/src/main/java/io/microsphere/nacos/client/v1/config/util/ConfigUtil.java
+++ b/microsphere-nacos-openapi/src/main/java/io/microsphere/nacos/client/v1/config/util/ConfigUtil.java
@@ -44,6 +44,9 @@ public abstract class ConfigUtil {
      * @return dataId^2Group^2contentMD5^2tenant
      */
     public static String buildListeningConfigDataPacket(String namespaceId, String group, String dataId, String contentMD5) {
+        if (namespaceId == null || namespaceId.isEmpty()) {
+            return doBuildConfigId(dataId, group, contentMD5);
+        }
         return doBuildConfigId(dataId, group, contentMD5, namespaceId);
     }
 
@@ -57,6 +60,9 @@ public abstract class ConfigUtil {
      * @return tenant^2Group^2dataId
      */
     public static String buildConfigId(String namespaceId, String group, String dataId) {
+        if (namespaceId == null || namespaceId.isEmpty()) {
+            return doBuildConfigId(dataId, group);
+        }
         return doBuildConfigId(dataId, group, namespaceId);
     }
 

--- a/microsphere-nacos-openapi/src/main/java/io/microsphere/nacos/client/v2/config/OpenApiConfigClientV2.java
+++ b/microsphere-nacos-openapi/src/main/java/io/microsphere/nacos/client/v2/config/OpenApiConfigClientV2.java
@@ -31,20 +31,7 @@ import static io.microsphere.nacos.client.OpenApiVersion.V1;
 import static io.microsphere.nacos.client.OpenApiVersion.V2;
 import static io.microsphere.nacos.client.http.HttpMethod.GET;
 import static io.microsphere.nacos.client.http.HttpMethod.POST;
-import static io.microsphere.nacos.client.transport.OpenApiRequestParam.CONFIG_APP;
-import static io.microsphere.nacos.client.transport.OpenApiRequestParam.CONFIG_CONTENT;
-import static io.microsphere.nacos.client.transport.OpenApiRequestParam.CONFIG_DATA_ID;
-import static io.microsphere.nacos.client.transport.OpenApiRequestParam.CONFIG_EFFECT;
-import static io.microsphere.nacos.client.transport.OpenApiRequestParam.CONFIG_GROUP;
-import static io.microsphere.nacos.client.transport.OpenApiRequestParam.CONFIG_SCHEMA;
-import static io.microsphere.nacos.client.transport.OpenApiRequestParam.CONFIG_TAG;
-import static io.microsphere.nacos.client.transport.OpenApiRequestParam.CONFIG_TAGS_V2;
-import static io.microsphere.nacos.client.transport.OpenApiRequestParam.CONFIG_TENANT;
-import static io.microsphere.nacos.client.transport.OpenApiRequestParam.CONFIG_USE;
-import static io.microsphere.nacos.client.transport.OpenApiRequestParam.DESCRIPTION;
-import static io.microsphere.nacos.client.transport.OpenApiRequestParam.NAMESPACE_ID;
-import static io.microsphere.nacos.client.transport.OpenApiRequestParam.OPERATOR_V2;
-import static io.microsphere.nacos.client.transport.OpenApiRequestParam.SHOW;
+import static io.microsphere.nacos.client.transport.OpenApiRequestParam.*;
 import static io.microsphere.nacos.client.util.StringUtils.collectionToCommaDelimitedString;
 
 /**
@@ -110,6 +97,8 @@ public class OpenApiConfigClientV2 extends OpenApiConfigClient implements Config
         String use = newConfig.getUse();
         String effect = newConfig.getEffect();
         String schema = newConfig.getSchema();
+        ConfigType configType = newConfig.getType();
+        String type = configType == null ? null : configType.getValue();
         OpenApiRequest request = configRequestBuilder(namespaceId, group, dataId, null, POST)
                 .queryParameter(CONFIG_CONTENT, content)
                 .queryParameter(CONFIG_TAGS_V2, tags)
@@ -119,6 +108,7 @@ public class OpenApiConfigClientV2 extends OpenApiConfigClient implements Config
                 .queryParameter(CONFIG_USE, use)
                 .queryParameter(CONFIG_EFFECT, effect)
                 .queryParameter(CONFIG_SCHEMA, schema)
+                .queryParameter(CONFIG_TYPE, type.toLowerCase())
                 .build();
         return response(request, Boolean.class);
     }


### PR DESCRIPTION
- bug1: 参数LONG_POLLING_TIMEOUT默认值使用微秒为单位，实际计划执行周期为毫秒

- bug2: 生成configId时，针对public命名空间，会导致多出%2字符，与nacos服务端不一致

|   namespace   | group | dataId | 修复前 | 修复后 |
| ----------- | ----------- | ---- | -------| -------| 
| public      | DEFAULT_GROUP| data.json| data.json%2DEFAULT_GROUP **%2** %1 | data.json%2DEFAULT_GROUP%1|
| namespaceId   | DEFAULT_GROUP   | data.json| data.json%2DEFAULT_GROUP%2namespaceId%1 | data.json%2DEFAULT_GROUP%2namespaceId%1 |

- bug3: v2版本configClient推送配置时，忽略掉了type参数